### PR TITLE
Add optional metrics and upgrade circe

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -35,9 +35,10 @@ resolvers ++= Seq(
 )
 
 libraryDependencies ++= Seq(
-  "io.circe" %% "circe-parser" % "0.7.0",
-  "io.circe" %% "circe-generic" % "0.7.0",
-  "com.beachape" %% "enumeratum-circe" % "1.5.14"
+  "io.circe" %% "circe-parser" % "0.8.0",
+  "io.circe" %% "circe-generic" % "0.8.0",
+  "com.beachape" %% "enumeratum-circe" % "1.5.14",
+  "joda-time" % "joda-time" % "2.9.9"
 )
 
 lazy val root = project in file(".")

--- a/src/main/scala/com/gu/editorialproductionmetricsmodels/models/MetricOpt.scala
+++ b/src/main/scala/com/gu/editorialproductionmetricsmodels/models/MetricOpt.scala
@@ -1,0 +1,41 @@
+package com.gu.editorialproductionmetricsmodels.models
+
+import io.circe._
+import io.circe.generic.semiauto.{deriveDecoder, deriveEncoder}
+import io.circe.syntax._
+import org.joda.time.DateTime
+
+case class MetricOpt(
+  id: Option[String] = None,
+  originatingSystem: Option[OriginatingSystem] = None,
+  composerId: Option[String] = None,
+  storyBundleId: Option[String] = None,
+  commissioningDesk: Option[String] = None,
+  userDesk: Option[String] = None,
+  inWorkflow: Option[Boolean] = None,
+  inNewspaper: Option[Boolean] = None,
+  creationTime: Option[DateTime] = None,
+  roundTrip: Option[Boolean] = None)
+
+object MetricOpt {
+  private val datePattern = "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'"
+  implicit val timeEncoder = new Encoder[DateTime] {
+    def apply(d: DateTime): Json = d.toString(datePattern).asJson
+  }
+  implicit val dateDecoder = new Decoder[DateTime] {
+    def apply(c: HCursor): Decoder.Result[DateTime] = {
+      val dateTime = for {
+        value <- c.focus
+        string <- value.asString
+      } yield new DateTime(string)
+      dateTime.fold[Decoder.Result[DateTime]](Left(DecodingFailure("could not decode date", c.history)))(dt => Right(dt))
+    }
+  }
+
+  implicit val metricEncoder: Encoder[MetricOpt] = deriveEncoder
+  implicit val metricDecoder: Decoder[MetricOpt] = deriveDecoder
+
+  // Because this lib is using Circe, but apps that use it might be using play-json, we've provided this
+  // toJsonString method to allow parsing with the correct one on the app side.
+  def toJsonString(metricOpt: MetricOpt): String = metricOpt.asJson.asString.getOrElse("")
+}


### PR DESCRIPTION
This will be used by apps that want to post data to the metrics project.

Notice that because of the use of different json parsing libs (circe and json play) a `toJsonString` method has been added.