### PR TITLE
Set boolean fields to correct defaults

### DIFF
--- a/src/main/scala/com/gu/editorialproductionmetricsmodels/models/MetricOpt.scala
+++ b/src/main/scala/com/gu/editorialproductionmetricsmodels/models/MetricOpt.scala
@@ -12,10 +12,10 @@ case class MetricOpt(
   storyBundleId: Option[String] = None,
   commissioningDesk: Option[String] = None,
   userDesk: Option[String] = None,
-  inWorkflow: Option[Boolean] = None,
-  inNewspaper: Option[Boolean] = None,
+  inWorkflow: Option[Boolean] = Some(false),
+  inNewspaper: Option[Boolean] = Some(false),
   creationTime: Option[DateTime] = None,
-  roundTrip: Option[Boolean] = None,
+  roundTrip: Option[Boolean] = Some(false),
   productionOffice: Option[ProductionOffice] = None)
 
 object MetricOpt {


### PR DESCRIPTION
These fields are not null in the db and not setting the correct defaults here result in db errors.