### PR TITLE
Remove defaults for MetricOpt

### DIFF
--- a/src/main/scala/com/gu/editorialproductionmetricsmodels/models/MetricOpt.scala
+++ b/src/main/scala/com/gu/editorialproductionmetricsmodels/models/MetricOpt.scala
@@ -12,11 +12,11 @@ case class MetricOpt(
   storyBundleId: Option[String] = None,
   commissioningDesk: Option[String] = None,
   userDesk: Option[String] = None,
-  inWorkflow: Option[Boolean] = Some(false),
-  inNewspaper: Option[Boolean] = Some(false),
+  inWorkflow: Option[Boolean] = None,
+  inNewspaper: Option[Boolean] = None,
   creationTime: Option[DateTime] = None,
   firstPublicationTime: Option[DateTime] = None,
-  roundTrip: Option[Boolean] = Some(false),
+  roundTrip: Option[Boolean] = None,
   productionOffice: Option[ProductionOffice] = None)
 
 object MetricOpt {


### PR DESCRIPTION
We can't set defaults here because they will override the changes that are already in the db. The db defaults should be enough.