### PR TITLE
Bump circe library version

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -37,8 +37,8 @@ resolvers ++= Seq(
 publishTo := sonatypePublishTo.value
 
 libraryDependencies ++= Seq(
-  "io.circe" %% "circe-parser" % "0.12.0",
-  "io.circe" %% "circe-generic" % "0.12.0",
+  "io.circe" %% "circe-parser" % "0.12.1",
+  "io.circe" %% "circe-generic" % "0.12.1",
   "com.beachape" %% "enumeratum-circe" % "1.5.18",
   "joda-time" % "joda-time" % "2.10.1"
 )

--- a/build.sbt
+++ b/build.sbt
@@ -37,8 +37,8 @@ resolvers ++= Seq(
 publishTo := sonatypePublishTo.value
 
 libraryDependencies ++= Seq(
-  "io.circe" %% "circe-parser" % "0.11.0",
-  "io.circe" %% "circe-generic" % "0.11.0",
+  "io.circe" %% "circe-parser" % "0.12.0",
+  "io.circe" %% "circe-generic" % "0.12.0",
   "com.beachape" %% "enumeratum-circe" % "1.5.18",
   "joda-time" % "joda-time" % "2.10.1"
 )


### PR DESCRIPTION
## What does this change?
This is required to facilitate upgrading editorial-production-metrics to Play 2.7 - https://github.com/guardian/editorial-production-metrics/pull/240 
