### PR TITLE
Bump to Scala 2.13 and SBT 1.8.2

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -6,7 +6,7 @@ description := "Scala library of shared models for production metrics."
 
 organization := "com.gu"
 
-scalaVersion := "2.12.8"
+scalaVersion := "2.13.10"
 
 scmInfo :=  Some(ScmInfo(
   url("https://github.com/guardian/editorial-production-metrics-lib"),
@@ -34,10 +34,10 @@ resolvers ++= Resolver.sonatypeOssRepos("releases")
 publishTo := sonatypePublishTo.value
 
 libraryDependencies ++= Seq(
-  "io.circe" %% "circe-parser" % "0.12.1",
-  "io.circe" %% "circe-generic" % "0.12.1",
-  "com.beachape" %% "enumeratum-circe" % "1.5.18",
-  "joda-time" % "joda-time" % "2.10.1"
+  "io.circe" %% "circe-parser" % "0.14.3",
+  "io.circe" %% "circe-generic" % "0.14.3",
+  "com.beachape" %% "enumeratum-circe" % "1.7.2",
+  "joda-time" % "joda-time" % "2.12.2"
 )
 
 lazy val root = project in file(".")

--- a/build.sbt
+++ b/build.sbt
@@ -27,12 +27,9 @@ pomExtra := (
     </developers>
   )
 
-licenses := Seq("Apache V2" -> url("http://www.apache.org/licenses/LICENSE-2.0.html"))
+licenses := Seq("Apache V2" -> url("https://www.apache.org/licenses/LICENSE-2.0.html"))
 
-resolvers ++= Seq(
-  "Guardian Github Releases" at "http://guardian.github.io/maven/repo-releases",
-  Resolver.sonatypeRepo("releases")
-)
+resolvers ++= Resolver.sonatypeOssRepos("releases")
 
 publishTo := sonatypePublishTo.value
 

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 1.2.8
+sbt.version = 1.8.2

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,9 +1,7 @@
-logLevel := Level.Warn
+addSbtPlugin("com.github.sbt" % "sbt-release" % "1.1.0")
 
-addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.11")
+addSbtPlugin("com.github.sbt" % "sbt-pgp" % "2.2.1")
 
-addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.1.1")
+addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.9.17")
 
-addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "2.3")
-
-addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.10.0-RC1")
+addDependencyTreePlugin

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.20-SNAPSHOT"
+ThisBuild / version := "0.20-SNAPSHOT"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-ThisBuild / version := "0.20-SNAPSHOT"
+ThisBuild / version := "0.20"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-ThisBuild / version := "0.20"
+ThisBuild / version := "0.21-SNAPSHOT"


### PR DESCRIPTION
## What does this change?
This bumps SBT to latest and Scala to 2.13, in order to facilitate updates in the two projects that consume this library:
https://github.com/guardian/editorial-production-metrics/pull/247 and https://github.com/guardian/production-metrics-lambdas/pull/14

## How to test
You can build this library locally using `sbt publishLocal` and test it against one of the linked prs above
